### PR TITLE
Fix deprecation warning about ufl_domain

### DIFF
--- a/src/fenicsx_pulse/active_model.py
+++ b/src/fenicsx_pulse/active_model.py
@@ -117,4 +117,4 @@ class Passive(ActiveModel):
         return F
 
     def strain_energy(self, F: ufl.core.expr.Expr) -> ufl.core.expr.Expr:
-        return dolfinx.fem.Constant(F.ufl_domain(), 0.0)
+        return dolfinx.fem.Constant(ufl.domain.extract_unique_domain(F), 0.0)

--- a/src/fenicsx_pulse/active_stress.py
+++ b/src/fenicsx_pulse/active_stress.py
@@ -57,12 +57,12 @@ class ActiveStress(ActiveModel):
     def __post_init__(self) -> None:
         if self.activation is None:
             self.activation = dolfinx.fem.Constant(
-                self.f0.ufl_domain(),
+                ufl.domain.extract_unique_domain(self.f0),
                 dolfinx.default_scalar_type(0.0),
             )
 
-        self.T_ref = dolfinx.fem.Constant(self.f0.ufl_domain(), self.T_ref)
-        self.eta = dolfinx.fem.Constant(self.f0.ufl_domain(), self.eta)
+        self.T_ref = dolfinx.fem.Constant(ufl.domain.extract_unique_domain(self.f0), self.T_ref)
+        self.eta = dolfinx.fem.Constant(ufl.domain.extract_unique_domain(self.f0), self.eta)
 
     @property
     def Ta(self) -> ufl.core.expr.Expr:


### PR DESCRIPTION
Fix deprecation warning
```
/usr/local/lib/python3.10/dist-packages/ufl/core/expr.py:264: DeprecationWarning: Expr.ufl_domain() is deprecated, please use extract_unique_domain(expr) instead.
```

See https://github.com/FEniCS/ufl/pull/131

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

