### PR TITLE
Install scifem with no-build-isolation in CI

### DIFF
--- a/.github/workflows/test_package_coverage.yml
+++ b/.github/workflows/test_package_coverage.yml
@@ -25,7 +25,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install package
-        run: python3 -m pip install .[test]
+        run: |
+          python3 -m pip install scifem --no-build-isolation
+          python3 -m pip install .[test]
 
       - name: Run tests
         run: python3 -m pytest -m "not benchmark"


### PR DESCRIPTION
Installation of scifem might not work with pure `pip install` because `nanobind` used to build `scifem` might be incompatible with `nanobind` used to build `dolfinx`. Therefore, we use the version of `nanobind` that is allready installed in the environment.